### PR TITLE
Adjusted contract to compile under solidity 0.4.24-0.5.x and truffle 5

### DIFF
--- a/contracts/Arithmetic.sol
+++ b/contracts/Arithmetic.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // Arithmetic library
 library Arithmetic {

--- a/contracts/Arithmetic.sol
+++ b/contracts/Arithmetic.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.8;
+pragma solidity 0.4.24;
 
 // Arithmetic library
 library Arithmetic {
     function mul256By256(uint a, uint b)
-        constant
+        pure public
         returns (uint ab32, uint ab1, uint ab0)
     {
         uint ahi = a >> 128;
@@ -21,7 +21,7 @@ library Arithmetic {
     // Algorithm 3.4: Divide-and-conquer division (3 by 2)
     // Karl got it from Burnikel and Ziegler and the GMP lib implementation
     function div256_128By256(uint a21, uint a0, uint b)
-        constant
+        pure public
         returns (uint q, uint r)
     {
         uint qhi = (a21 / b) << 128;
@@ -33,7 +33,7 @@ library Arithmetic {
         a21 = (a21 << shift) + (shift > 128 ? a0 << (shift - 128) : a0 >> (128 - shift));
         a0 = (a0 << shift) & 2**128-1;
         b <<= shift;
-        var (b1, b0) = (b >> 128, b & 2**128-1);
+        (uint256 b1, uint256 b0) = (b >> 128, b & 2**128-1);
 
         uint rhi;
         q = a21 / b1;
@@ -55,6 +55,7 @@ library Arithmetic {
     }
 
     function overflowResistantFraction(uint a, uint b, uint divisor)
+        pure public
         returns (uint)
     {
         uint ab32_q1; uint ab1_r1; uint ab0;

--- a/contracts/Arithmetic.sol
+++ b/contracts/Arithmetic.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.4.24 <0.6.0;
 // Arithmetic library
 library Arithmetic {
     function mul256By256(uint a, uint b)
-        pure public
+        internal pure
         returns (uint ab32, uint ab1, uint ab0)
     {
         uint ahi = a >> 128;
@@ -21,7 +21,7 @@ library Arithmetic {
     // Algorithm 3.4: Divide-and-conquer division (3 by 2)
     // Karl got it from Burnikel and Ziegler and the GMP lib implementation
     function div256_128By256(uint a21, uint a0, uint b)
-        pure public
+        internal pure
         returns (uint q, uint r)
     {
         uint qhi = (a21 / b) << 128;
@@ -55,7 +55,7 @@ library Arithmetic {
     }
 
     function overflowResistantFraction(uint a, uint b, uint divisor)
-        pure public
+        internal pure
         returns (uint)
     {
         uint ab32_q1; uint ab1_r1; uint ab0;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity 0.4.24;
 
 contract Migrations {
   address public owner;
@@ -8,15 +8,15 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  constructor() public {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) restricted {
+  function upgrade(address new_address) public restricted {
     Migrations upgraded = Migrations(new_address);
     upgraded.setCompleted(last_completed_migration);
   }


### PR DESCRIPTION
Because the solidity version was prefixed with `^`, the contract was not compiling even when used as a library under Truffle 5. Under truffle 4, several compiler warnings were also being displayed. I've resolved these warnings and pinned both `Arithmetic.sol` and `Migrations.sol` to Solidity version 0.4.24. All tests still pass, as the changes I've made do not modify the behavior of the contract in any way.

Thanks for taking the time to write this library out.